### PR TITLE
fixed no pagebreak being inserted on empty line

### DIFF
--- a/summernote-pagebreak.js
+++ b/summernote-pagebreak.js
@@ -32,18 +32,22 @@
         var button = ui.button({
           contents: options.pagebreak.icon,
           tooltip:  lang.pagebreak.tooltip,
-          click:function(e) {
+          container: 'body',
+          click: function (e) {
             e.preventDefault();
             if (getSelection().rangeCount > 0) {
               var el = getSelection().getRangeAt(0).commonAncestorContainer.parentNode;
-              if (!$(el).hasClass('.page-break')) {
+              if ($(el).hasClass('note-editable')) {
+                el = getSelection().getRangeAt(0).commonAncestorContainer;
+              }
+              if (!$(el).hasClass('page-break')) {
                 if ($(el).next('div.page-break').length < 1)
                   $('<div class="page-break"></div>').insertAfter(el);
               }
             } else {
-              if ($('.note-editable div').last().attr('class') != 'page-break')
+              if ($('.note-editable div').last().attr('class') !== 'page-break')
                 $('.note-editable').append('<div class="page-break"></div>');
-            }
+              }
           }
         });
         return button.render();


### PR DESCRIPTION
- fixed no pagebreak being inserted on empty line, as seen on issue #1 
- this also fixes page-break divs being inserted into unrelated DOM elements
- fixed missing tooltip by adding "container: 'body'" to options, as this is apparently necessary with new versions of summernote.
