### PR TITLE
Fixed the non-syncing content insertion

### DIFF
--- a/summernote-pagebreak.js
+++ b/summernote-pagebreak.js
@@ -47,7 +47,10 @@
             } else {
               if ($('.note-editable div').last().attr('class') !== 'page-break')
                 $('.note-editable').append('<div class="page-break"></div>');
-              }
+            }
+
+            // Launching this method to force Summernote sync it's content with the bound textarea element
+            context.invoke('editor.insertText','');
           }
         });
         return button.render();


### PR DESCRIPTION
Adding a single line of code to force Summernote sync its content with the bound textarea element.